### PR TITLE
Vagrant dev environment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The sample vulnerable apps and other utilities run in VMs on your local machine,
 So you'll need to install VirtualBox (you will need the latest version if you have windows 10) and Vagrant.
 See https://docs.vagrantup.com/v2/getting-started/index.html if you haven't used Vagrant before.
 
-The sample apps are node apps running on an ubuntu 14.04 VM. In these VMs the /vagrant directory is mapped to the project folder of the  The samples are run by a gulp task which watches the source files. Editing and saving source will trigger gulp task to build and restart the server, so no IDE build is required. So branching and modifying the code should also 'just work', fingers crossed. N.B. This isn't working yet. :-(
+The sample apps are node apps running on an ubuntu 14.04 VM. In these VMs the /vagrant directory is mapped to the project folder of the  The samples are run by a gulp task which watches the source files. Editing and saving source will trigger gulp task to build and restart the server, so no IDE build is required. So branching and modifying the code should also 'just work', fingers crossed.
 
 **Important.** When the vagrant file is created it installs (and where necessary builds) node packages on the (ubuntu) VM. If you run npm install on your local Windows machine it will almost certainly break your VM and you will need to recreate it. Attempting to run the samples on both the VM and locally will end in tears of rage and frustration - it's an interesting problem in itself, but has nothing to do with this course.
 
@@ -43,11 +43,13 @@ To run any of the samples, you navigate to the project folder. There will be a v
 
 	vagrant up
 
+**You must run this in an administrator command prompt on Windows**, otherwise the VM will not be able to create symlinks.
+
 N.B. This will take quite a while the first time you start a VM, especially the first time
 
 When you're done (temporarily), halt it with:
 
-	vagrant up
+	vagrant halt
 	
 Next time you start it will be faster to load. Or take it down completely with:
 

--- a/Samples/MEAN_stack/Vagrantfile
+++ b/Samples/MEAN_stack/Vagrantfile
@@ -1,5 +1,8 @@
 Vagrant.configure("2") do |config|
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+  end
   config.vm.box = "ubuntu/trusty64"
-  config.vm.provision :shell, path: "vagrant_bootstrap.sh"
+  config.vm.provision :shell, inline: "apt-get install dos2unix && dos2unix /vagrant/vagrant_bootstrap.sh && /vagrant/vagrant_bootstrap.sh", run: "always"
   config.vm.network "private_network", ip: "10.10.10.10"
 end

--- a/Samples/MEAN_stack/vagrant_bootstrap.sh
+++ b/Samples/MEAN_stack/vagrant_bootstrap.sh
@@ -1,4 +1,4 @@
-﻿#!sh
+#!/bin/sh
 
 # Required for mongodb install
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10

--- a/Samples/MEAN_stack/vagrant_bootstrap.sh
+++ b/Samples/MEAN_stack/vagrant_bootstrap.sh
@@ -25,4 +25,4 @@ cp /vagrant/MEAN_stack.conf /etc/init
 cd /vagrant
 
 # And start the server
-sudo nodejs server.js
+gulp dev


### PR DESCRIPTION
Ran into a few problems getting Vagrant off the ground that this PR should hopefully fix.

Initially the server would not start because the node_modules were missing (complained Express couldn't be found). This was because of how VirtualBox [handles symlinks](https://github.com/mitchellh/vagrant/issues/713#issuecomment-13201507). Newer versions of VB now allow symlinks by default, but I've added a few lines to enable it on older versions. VB also needs to run as admin so I've put a note in the instructions to reflect this.

I also had a few problems with the bootstrap file and *sh* objecting to CRLF when saved in Windows. Not the nicest fix, but installing and running dos2unix before invoking the script should sort this. The provision command is now also set to run every time.

Finally, changed the bootstrap file to run gulp instead of just express. Haven't had any problems with the watcher on the files in the *ng/* directory. Should the watcher also be monitoring other files?
