### PR TITLE
Attacker Site Date Sort

### DIFF
--- a/Samples/Attacker_site/controllers/api/logs.js
+++ b/Samples/Attacker_site/controllers/api/logs.js
@@ -16,6 +16,7 @@ router.get('/', function (req, res, next) {
 
 router.get('/add', function (req, res, next) {
     var log = new Log({
+        date: new Date().valueOf(),
         origin: req.query.origin,
         value: req.query.value,
         type: req.query.type,

--- a/Samples/Attacker_site/models/log.js
+++ b/Samples/Attacker_site/models/log.js
@@ -1,6 +1,7 @@
 ﻿var db = require('../db');
 
 var Log = db.model('Log', {
+    date: { type: Number, required: true},
     origin: { type: String, required: true },
     value: { type: String, required: true },
     type: { type: String, required: true }


### PR DESCRIPTION
Adds a date field to the attacker site (the current time is used) so the newest data is at the top. The sort is already in place in `controllers/api/logs.js`.